### PR TITLE
shape誤り修正: sh:uniqLang to sh:uniqueLang

### DIFF
--- a/dataset/idol_shape.ttl
+++ b/dataset/idol_shape.ttl
@@ -27,12 +27,12 @@ mltd-shape:IdolShape a sh:NodeShape;
     sh:property [
         sh:path :familyName;
         sh:datatype rdf:langString;
-        sh:uniqLang true;
+        sh:uniqueLang true;
     ];
     sh:property [
         sh:path :givenName;
         sh:datatype rdf:langString;
-        sh:uniqLang true;
+        sh:uniqueLang true;
     ];
     sh:property [
         sh:path :height;

--- a/rdflint-config.yml
+++ b/rdflint-config.yml
@@ -2,6 +2,10 @@ targetDir: dataset
 outputDir: .
 baseUri: https://mltd.pikopikopla.net/
 validation:
+  undefinedSubject:
+    - url: https://www.w3.org/2002/07/owl
+      startswith: http://www.w3.org/2002/07/owl#
+      langtype: turtle
   fileEncoding:
     - target: "*"
       charset: utf-8


### PR DESCRIPTION
Shape定義にミスがあったので、修正しています。

あわせて、  
rdflint0.1.3で、未定義主語の使用検証の対象を設定で追加出来るようにしたので、
`http://www.w3.org/2002/07/owl#` を設定しています。
